### PR TITLE
Add DataContractJsonSerializer support as a proof of concept.

### DIFF
--- a/GeeklistSharp/GeeklistSharp.csproj
+++ b/GeeklistSharp/GeeklistSharp.csproj
@@ -36,6 +36,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -44,8 +45,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Globals.cs" />
+    <Compile Include="Model\GeekListException.cs" />
     <Compile Include="Model\OAuthAccessToken.cs" />
     <Compile Include="Model\OAuthRequestToken.cs" />
+    <Compile Include="Model\Response.cs" />
+    <Compile Include="Model\User.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Service\GeeklistService.cs" />
   </ItemGroup>

--- a/GeeklistSharp/Model/GeekListException.cs
+++ b/GeeklistSharp/Model/GeekListException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace GeeklistSharp.Model
+{
+	public class GeekListException : Exception
+	{
+		public string Status { get; private set; }
+
+		public GeekListException(string status)
+			: base(string.Format("API call resulted in status: {0}", status))
+		{
+			this.Status = status;
+		}
+	}
+}

--- a/GeeklistSharp/Model/Response.cs
+++ b/GeeklistSharp/Model/Response.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.Serialization;
+
+namespace GeeklistSharp.Model
+{
+	[DataContract]
+	public class Response<T> 
+	{
+		[DataMember(Name = "status")]
+		public string Status { get; set; }
+
+		[DataMember(Name = "data")]
+		public T Data { get; set; }
+	}
+}

--- a/GeeklistSharp/Model/User.cs
+++ b/GeeklistSharp/Model/User.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.Serialization;
+
+namespace GeeklistSharp.Model
+{
+	[DataContract]
+	public class User
+	{
+		[DataMember(Name = "id")]
+		public string Id { get; set; }
+
+		[DataMember(Name = "name")]
+		public string Name { get; set; }
+
+		[DataMember(Name = "screen_name")]
+		public string ScreenName { get; set; }
+	}
+}

--- a/GeeklistSharp/Service/GeeklistService.cs
+++ b/GeeklistSharp/Service/GeeklistService.cs
@@ -7,6 +7,8 @@ using Hammock.Authentication.OAuth;
 using Hammock.Web;
 using System.Compat.Web;
 using GeeklistSharp.Model;
+using System.Runtime.Serialization.Json;
+using System.IO;
 
 namespace GeeklistSharp.Service
 {
@@ -129,9 +131,24 @@ namespace GeeklistSharp.Service
 
             var response = _oauth.Request(request);
 
-            //TODO: Parse this json string and convert it into the object we are looking for.
+			var result = GetResponse<User>(response.ContentStream);
 
-            return response.Content;
+			if (result.Status != "ok")
+			{
+				throw new GeekListException(result.Status);
+			}
+
+            return result.Data;
         }
+
+		protected virtual Response<T> GetResponse<T>(Stream jsonStream)
+			where T : new()
+		{
+			var serializer = new DataContractJsonSerializer(typeof(Response<T>));
+
+			var result = (Response<T>)serializer.ReadObject(jsonStream);
+
+			return result;
+		}
     }
 }


### PR DESCRIPTION
Think this will work? I like it simply because its built in to the framework and we can separate json data field names from C# property names. 

The only downside I see is that it doesn't support Enums, but I don't think there's a reason to use them anywhere.
